### PR TITLE
chore: split the ClusterSecretStore into its own addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ Then template the chart to file
 helm template external-secrets external-secrets/external-secrets -n kube-system --values values.yaml >| external-secrets.yaml
 ```
 
-And lastly add the cluster secret store
-```shell
-cat cluster-secret-store.yaml >> external-secrets.yaml
-```
-
 Check the changes and if everything looks correct, commit, push and PR.
+
+## Releasing
+Make sure to update the `version` for the `external-secrets` addon to match the planned tag/release version before
+tagging the commit.
+
+```terraform
+
+output "addons" {
+  value = [
+    {
+      name : "external-secrets"
+      version : "0.6.0"
+      content : local.external_secrets_yaml
+    },
+  ]
+}
+```

--- a/examples/basic/k8s.tf
+++ b/examples/basic/k8s.tf
@@ -24,6 +24,7 @@ resource "aws_iam_role" "kubernetes_admin" {
 
 module "external_secrets" {
   source = "../../"
+  region = local.region
 }
 
 module "state_store" {
@@ -59,7 +60,6 @@ module "k8s" {
   service_account_external_permissions = [
     module.external_secrets.permissions
   ]
-  extra_addons = [
-    module.external_secrets.addon
-  ]
+  extra_addons = module.external_secrets.addons
+
 }

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -6,7 +6,6 @@ provider "aws" {
   skip_requesting_account_id  = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
-  s3_force_path_style         = true
   region                      = "eu-west-1"
   access_key                  = "mock_access_key"
   secret_key                  = "mock_secret_key"

--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -6292,13 +6292,3 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 5
   failurePolicy: Fail
----
-apiVersion: external-secrets.io/v1beta1
-kind: ClusterSecretStore
-metadata:
-  name: external-secrets
-spec:
-  provider:
-    aws:
-      service: SecretsManager
-      region: ${region}

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,6 @@
 locals {
   external_secrets_yaml = file("${path.module}/external-secrets.yaml")
+  external_secrets_store_yaml = templatefile("${path.module}/cluster-secret-store.yaml", {
+    region = var.region
+  })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,10 +23,17 @@ output "permissions" {
   }
 }
 
-output "addon" {
-  value = {
-    name : "external-secrets"
-    version : "0.6.0"
-    content : local.external_secrets_yaml
-  }
+output "addons" {
+  value = [
+    {
+      name : "external-secrets"
+      version : "0.6.0.1"
+      content : local.external_secrets_yaml
+    },
+    {
+      name : "external-secrets-store"
+      version : "0.0.1"
+      content : local.external_secrets_store_yaml
+    },
+  ]
 }

--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  description = "The AWS region where the K8S cluster is running"
+}
+


### PR DESCRIPTION
Updating the addon fails since the CA bundle is overwritteen by the server-side apply performed by kops addon channels.