### PR TITLE
chore: remove IRSA volume mounts

### DIFF
--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -6160,32 +6160,10 @@ spec:
             - containerPort: 8080
               protocol: TCP
               name: metrics
-          env:
-            - name: AWS_DEFAULT_REGION
-              value: ${region}
-            - name: AWS_REGION
-              value: ${region}
-            - name: AWS_ROLE_ARN
-              value: arn:aws:iam::${account_id}:role/external-secrets.kube-system.sa.${name}
-            - name: AWS_WEB_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/amazonaws.com/serviceaccount/token
-            - name: AWS_STS_REGIONAL_ENDPOINTS
-              value: regional
           resources:
             requests:
               cpu: 10m
               memory: 32Mi
-          volumeMounts:
-            - mountPath: /var/run/secrets/amazonaws.com/serviceaccount/
-              name: aws-token
-      volumes:
-        - name: aws-token
-          projected:
-            sources:
-            - serviceAccountToken:
-                audience: amazonaws.com
-                expirationSeconds: 86400
-                path: token
 ---
 # Source: external-secrets/templates/webhook-deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Requires that pod identity webhook is used. See
https://kops.sigs.k8s.io/addons/#pod-identity-webhook Releases of module terraform-k8s after 0.6.1 and 0.7.1 support this, https://github.com/opzkit/terraform-aws-k8s/releases/tag/v0.7.1 https://github.com/opzkit/terraform-aws-k8s/releases/tag/v0.6.1