### PR TITLE
Update External Secrets Operator version

### DIFF
--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: acraccesstokens.generators.external-secrets.io
 spec:
   conversion:
@@ -208,6 +210,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: clusterexternalsecrets.external-secrets.io
 spec:
   conversion:
@@ -904,6 +908,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: clustersecretstores.external-secrets.io
 spec:
   conversion:
@@ -2555,6 +2561,11 @@ spec:
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
                     for a ClusterSecretStore instance.
                   properties:
+                    namespaceRegexes:
+                      description: Choose namespaces by using regex matching
+                      items:
+                        type: string
+                      type: array
                     namespaceSelector:
                       description: Choose namespace using a labelSelector
                       properties:
@@ -3198,6 +3209,68 @@ spec:
                     required:
                     - vaultUrl
                     type: object
+                  bitwardensecretsmanager:
+                    description: BitwardenSecretsManager configures this store to
+                      sync secrets using BitwardenSecretsManager provider
+                    properties:
+                      apiURL:
+                        type: string
+                      auth:
+                        description: |-
+                          Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                          Make sure that the token being used has permissions on the given secret.
+                        properties:
+                          secretRef:
+                            description: BitwardenSecretsManagerSecretRef contains
+                              the credential ref to the bitwarden instance.
+                            properties:
+                              credentials:
+                                description: AccessToken used for the bitwarden instance.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                            - credentials
+                            type: object
+                        required:
+                        - secretRef
+                        type: object
+                      bitwardenServerSDKURL:
+                        type: string
+                      caBundle:
+                        description: |-
+                          Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                          can be performed.
+                        type: string
+                      identityURL:
+                        type: string
+                      organizationID:
+                        description: OrganizationID determines which organization
+                          this secret store manages.
+                        type: string
+                      projectID:
+                        description: ProjectID determines which project this secret
+                          store manages.
+                        type: string
+                    required:
+                    - auth
+                    - caBundle
+                    - organizationID
+                    - projectID
+                    type: object
                   chef:
                     description: Chef configures this store to sync secrets with chef
                       server
@@ -3480,6 +3553,45 @@ spec:
                     - clientSecret
                     - tenant
                     type: object
+                  device42:
+                    description: Device42 configures this store to sync secrets using
+                      the Device42 provider
+                    properties:
+                      auth:
+                        description: Auth configures how secret-manager authenticates
+                          with a Device42 instance.
+                        properties:
+                          secretRef:
+                            properties:
+                              credentials:
+                                description: Username / Password is used for authentication.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            type: object
+                        required:
+                        - secretRef
+                        type: object
+                      host:
+                        description: URL configures the Device42 instance URL.
+                        type: string
+                    required:
+                    - auth
+                    - host
+                    type: object
                   doppler:
                     description: Doppler configures this store to sync secrets using
                       the Doppler provider
@@ -3672,6 +3784,10 @@ spec:
                             - serviceAccountRef
                             type: object
                         type: object
+                      location:
+                        description: Location optionally defines a location for a
+                          secret
+                        type: string
                       projectID:
                         description: ProjectID project where secret is located
                         type: string
@@ -3789,6 +3905,81 @@ spec:
                         type: string
                     required:
                     - auth
+                    type: object
+                  infisical:
+                    description: Infisical configures this store to sync secrets using
+                      the Infisical provider
+                    properties:
+                      auth:
+                        description: Auth configures how the Operator authenticates
+                          with the Infisical API
+                        properties:
+                          universalAuthCredentials:
+                            properties:
+                              clientId:
+                                description: |-
+                                  A reference to a specific 'key' within a Secret resource,
+                                  In some instances, `key` is a required field.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                              clientSecret:
+                                description: |-
+                                  A reference to a specific 'key' within a Secret resource,
+                                  In some instances, `key` is a required field.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                            - clientId
+                            - clientSecret
+                            type: object
+                        type: object
+                      hostAPI:
+                        default: https://app.infisical.com/api
+                        type: string
+                      secretsScope:
+                        properties:
+                          environmentSlug:
+                            type: string
+                          projectSlug:
+                            type: string
+                          secretsPath:
+                            default: /
+                            type: string
+                        required:
+                        - environmentSlug
+                        - projectSlug
+                        type: object
+                    required:
+                    - auth
+                    - secretsScope
                     type: object
                   keepersecurity:
                     description: KeeperSecurity configures this store to sync secrets
@@ -3923,6 +4114,25 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      authRef:
+                        description: A reference to a secret that contains the auth
+                          information.
+                        properties:
+                          key:
+                            description: |-
+                              The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                              defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: The name of the Secret resource being referred
+                              to.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                              to the namespace of the referent.
+                            type: string
+                        type: object
                       remoteNamespace:
                         default: default
                         description: Remote namespace to fetch the secrets from
@@ -3966,8 +4176,6 @@ spec:
                             description: configures the Kubernetes server Address.
                             type: string
                         type: object
-                    required:
-                    - auth
                     type: object
                   onboardbase:
                     description: Onboardbase configures this store to sync secrets
@@ -5396,6 +5604,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: ecrauthorizationtokens.generators.external-secrets.io
 spec:
   conversion:
@@ -5566,6 +5776,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: externalsecrets.external-secrets.io
 spec:
   conversion:
@@ -6415,6 +6627,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: fakes.generators.external-secrets.io
 spec:
   conversion:
@@ -6490,6 +6704,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: gcraccesstokens.generators.external-secrets.io
 spec:
   conversion:
@@ -6620,6 +6836,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: githubaccesstokens.generators.external-secrets.io
 spec:
   conversion:
@@ -6673,7 +6891,7 @@ spec:
               auth:
                 description: Auth configures how ESO authenticates with a Github instance.
                 properties:
-                  privatKey:
+                  privateKey:
                     properties:
                       secretRef:
                         description: |-
@@ -6699,7 +6917,7 @@ spec:
                     - secretRef
                     type: object
                 required:
-                - privatKey
+                - privateKey
                 type: object
               installID:
                 type: string
@@ -6722,6 +6940,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: passwords.generators.external-secrets.io
 spec:
   conversion:
@@ -7211,6 +7431,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: secretstores.external-secrets.io
 spec:
   conversion:
@@ -8862,6 +9084,11 @@ spec:
                     ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
                     for a ClusterSecretStore instance.
                   properties:
+                    namespaceRegexes:
+                      description: Choose namespaces by using regex matching
+                      items:
+                        type: string
+                      type: array
                     namespaceSelector:
                       description: Choose namespace using a labelSelector
                       properties:
@@ -9505,6 +9732,68 @@ spec:
                     required:
                     - vaultUrl
                     type: object
+                  bitwardensecretsmanager:
+                    description: BitwardenSecretsManager configures this store to
+                      sync secrets using BitwardenSecretsManager provider
+                    properties:
+                      apiURL:
+                        type: string
+                      auth:
+                        description: |-
+                          Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                          Make sure that the token being used has permissions on the given secret.
+                        properties:
+                          secretRef:
+                            description: BitwardenSecretsManagerSecretRef contains
+                              the credential ref to the bitwarden instance.
+                            properties:
+                              credentials:
+                                description: AccessToken used for the bitwarden instance.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                            - credentials
+                            type: object
+                        required:
+                        - secretRef
+                        type: object
+                      bitwardenServerSDKURL:
+                        type: string
+                      caBundle:
+                        description: |-
+                          Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                          can be performed.
+                        type: string
+                      identityURL:
+                        type: string
+                      organizationID:
+                        description: OrganizationID determines which organization
+                          this secret store manages.
+                        type: string
+                      projectID:
+                        description: ProjectID determines which project this secret
+                          store manages.
+                        type: string
+                    required:
+                    - auth
+                    - caBundle
+                    - organizationID
+                    - projectID
+                    type: object
                   chef:
                     description: Chef configures this store to sync secrets with chef
                       server
@@ -9787,6 +10076,45 @@ spec:
                     - clientSecret
                     - tenant
                     type: object
+                  device42:
+                    description: Device42 configures this store to sync secrets using
+                      the Device42 provider
+                    properties:
+                      auth:
+                        description: Auth configures how secret-manager authenticates
+                          with a Device42 instance.
+                        properties:
+                          secretRef:
+                            properties:
+                              credentials:
+                                description: Username / Password is used for authentication.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            type: object
+                        required:
+                        - secretRef
+                        type: object
+                      host:
+                        description: URL configures the Device42 instance URL.
+                        type: string
+                    required:
+                    - auth
+                    - host
+                    type: object
                   doppler:
                     description: Doppler configures this store to sync secrets using
                       the Doppler provider
@@ -9979,6 +10307,10 @@ spec:
                             - serviceAccountRef
                             type: object
                         type: object
+                      location:
+                        description: Location optionally defines a location for a
+                          secret
+                        type: string
                       projectID:
                         description: ProjectID project where secret is located
                         type: string
@@ -10096,6 +10428,81 @@ spec:
                         type: string
                     required:
                     - auth
+                    type: object
+                  infisical:
+                    description: Infisical configures this store to sync secrets using
+                      the Infisical provider
+                    properties:
+                      auth:
+                        description: Auth configures how the Operator authenticates
+                          with the Infisical API
+                        properties:
+                          universalAuthCredentials:
+                            properties:
+                              clientId:
+                                description: |-
+                                  A reference to a specific 'key' within a Secret resource,
+                                  In some instances, `key` is a required field.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                              clientSecret:
+                                description: |-
+                                  A reference to a specific 'key' within a Secret resource,
+                                  In some instances, `key` is a required field.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                      defaulted, in others it may be required.
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being
+                                      referred to.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                      to the namespace of the referent.
+                                    type: string
+                                type: object
+                            required:
+                            - clientId
+                            - clientSecret
+                            type: object
+                        type: object
+                      hostAPI:
+                        default: https://app.infisical.com/api
+                        type: string
+                      secretsScope:
+                        properties:
+                          environmentSlug:
+                            type: string
+                          projectSlug:
+                            type: string
+                          secretsPath:
+                            default: /
+                            type: string
+                        required:
+                        - environmentSlug
+                        - projectSlug
+                        type: object
+                    required:
+                    - auth
+                    - secretsScope
                     type: object
                   keepersecurity:
                     description: KeeperSecurity configures this store to sync secrets
@@ -10230,6 +10637,25 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      authRef:
+                        description: A reference to a secret that contains the auth
+                          information.
+                        properties:
+                          key:
+                            description: |-
+                              The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                              defaulted, in others it may be required.
+                            type: string
+                          name:
+                            description: The name of the Secret resource being referred
+                              to.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                              to the namespace of the referent.
+                            type: string
+                        type: object
                       remoteNamespace:
                         default: default
                         description: Remote namespace to fetch the secrets from
@@ -10273,8 +10699,6 @@ spec:
                             description: configures the Kubernetes server Address.
                             type: string
                         type: object
-                    required:
-                    - auth
                     type: object
                   onboardbase:
                     description: Onboardbase configures this store to sync secrets
@@ -11703,6 +12127,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: vaultdynamicsecrets.generators.external-secrets.io
 spec:
   conversion:
@@ -12427,6 +12853,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    external-secrets.io/component: controller
   name: webhooks.generators.external-secrets.io
 spec:
   conversion:
@@ -12581,8 +13009,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets
   namespace: kube-system
 ---
@@ -12593,8 +13021,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-cert-controller
   namespace: kube-system
 ---
@@ -12605,8 +13033,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -12617,8 +13045,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-leaderelection
   namespace: kube-system
 rules:
@@ -12655,8 +13083,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-cert-controller
 rules:
 - apiGroups:
@@ -12721,8 +13149,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-controller
 rules:
 - apiGroups:
@@ -12756,6 +13184,7 @@ rules:
   - pushsecrets/status
   - pushsecrets/finalizers
   verbs:
+  - get
   - update
   - patch
 - apiGroups:
@@ -12831,8 +13260,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit
@@ -12875,8 +13304,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:
@@ -12896,8 +13325,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -12937,8 +13366,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-leaderelection
   namespace: kube-system
 roleRef:
@@ -12957,8 +13386,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-cert-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12976,8 +13405,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12995,9 +13424,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.19
+    app.kubernetes.io/version: v0.9.20
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.9.19
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13008,9 +13437,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.19
+    app.kubernetes.io/version: v0.9.20
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.9.19
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -13031,8 +13460,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets
   namespace: kube-system
 spec:
@@ -13048,15 +13477,17 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.9.19
-        helm.sh/chart: external-secrets-0.9.19
+        app.kubernetes.io/version: v0.9.20
+        helm.sh/chart: external-secrets-0.9.20
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --concurrent=1
         - --metrics-addr=:8080
-        image: ghcr.io/external-secrets/external-secrets:v0.9.19
+        - --loglevel=info
+        - --zap-time-encoding=epoch
+        image: ghcr.io/external-secrets/external-secrets:v0.9.20
         imagePullPolicy: IfNotPresent
         name: external-secrets
         ports:
@@ -13088,8 +13519,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-cert-controller
   namespace: kube-system
 spec:
@@ -13105,8 +13536,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-cert-controller
-        app.kubernetes.io/version: v0.9.19
-        helm.sh/chart: external-secrets-0.9.19
+        app.kubernetes.io/version: v0.9.20
+        helm.sh/chart: external-secrets-0.9.20
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13119,7 +13550,10 @@ spec:
         - --secret-namespace=kube-system
         - --metrics-addr=:8080
         - --healthz-addr=:8081
-        image: ghcr.io/external-secrets/external-secrets:v0.9.19
+        - --loglevel=info
+        - --zap-time-encoding=epoch
+        - --enable-partial-cache=true
+        image: ghcr.io/external-secrets/external-secrets:v0.9.20
         imagePullPolicy: IfNotPresent
         name: cert-controller
         ports:
@@ -13156,8 +13590,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.19
-    helm.sh/chart: external-secrets-0.9.19
+    app.kubernetes.io/version: v0.9.20
+    helm.sh/chart: external-secrets-0.9.20
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -13173,8 +13607,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.9.19
-        helm.sh/chart: external-secrets-0.9.19
+        app.kubernetes.io/version: v0.9.20
+        helm.sh/chart: external-secrets-0.9.20
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13186,7 +13620,9 @@ spec:
         - --check-interval=5m
         - --metrics-addr=:8080
         - --healthz-addr=:8081
-        image: ghcr.io/external-secrets/external-secrets:v0.9.19
+        - --loglevel=info
+        - --zap-time-encoding=epoch
+        image: ghcr.io/external-secrets/external-secrets:v0.9.20
         imagePullPolicy: IfNotPresent
         name: webhook
         ports:

--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -5,7 +5,7 @@ helmCharts:
 - name: external-secrets
   namespace: kube-system
   repo: https://charts.external-secrets.io
-  version: '0.9.19'
+  version: '0.9.20'
   releaseName: external-secrets
   includeCRDs: true
   valuesFile: values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version               = "0.9.19"
+  version               = "0.9.20"
   external_secrets_yaml = file("${path.module}/external-secrets.yaml")
   external_secrets_store_yaml = templatefile("${path.module}/cluster-secret-store.yaml", {
     region = var.region


### PR DESCRIPTION



<Actions>
    <action id="0eb2ac8a3a9cb140b2ce30320ef08c2c349c525fc20928591c662dc122c9c9bd">
        <h3>EXTERNAL-SECRETS.YAML</h3>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.9.19&#34; to &#34;0.9.20&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>0.9.20</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-07-06 19:00:21.728692476 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.9.20/external-secrets-0.9.20.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf external-secrets/charts &amp;&amp; kubectl kustomize . -o external-secrets.yaml --enable-helm &amp;&amp; git diff --shortstat external-secrets.yaml&#34;</p>
        </details>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;0.9.19&#39;&#34; to &#34;&#39;0.9.20&#39;&#34;, in file &#34;external-secrets/kustomization.yaml&#34;</p>
            <details>
                <summary>0.9.20</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-07-06 19:00:21.728692476 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.9.20/external-secrets-0.9.20.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-external-secrets-operator/actions/runs/9823247178">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

