### PR TITLE
Update External Secrets Operator version

### DIFF
--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -2999,6 +2999,9 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      prefix:
+                        description: Prefix adds a prefix to all retrieved values.
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string
@@ -4553,7 +4556,7 @@ spec:
                             type: object
                         type: object
                       apiUrl:
-                        default: https://api.pulumi.com
+                        default: https://api.pulumi.com/api/preview
                         description: APIURL is the URL of the Pulumi API.
                         type: string
                       environment:
@@ -4646,6 +4649,75 @@ spec:
                     - projectId
                     - region
                     - secretKey
+                    type: object
+                  secretserver:
+                    description: |-
+                      SecretServer configures this store to sync secrets using SecretServer provider
+                      https://docs.delinea.com/online-help/secret-server/start.htm
+                    properties:
+                      password:
+                        description: Password is the secret server account password.
+                        properties:
+                          secretRef:
+                            description: SecretRef references a key in a secret that
+                              will be used as value.
+                            properties:
+                              key:
+                                description: |-
+                                  The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                  defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                  to the namespace of the referent.
+                                type: string
+                            type: object
+                          value:
+                            description: Value can be specified directly to set a
+                              value without using a secret.
+                            type: string
+                        type: object
+                      serverURL:
+                        description: |-
+                          ServerURL
+                          URL to your secret server installation
+                        type: string
+                      username:
+                        description: Username is the secret server account username.
+                        properties:
+                          secretRef:
+                            description: SecretRef references a key in a secret that
+                              will be used as value.
+                            properties:
+                              key:
+                                description: |-
+                                  The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                  defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                  to the namespace of the referent.
+                                type: string
+                            type: object
+                          value:
+                            description: Value can be specified directly to set a
+                              value without using a secret.
+                            type: string
+                        type: object
+                    required:
+                    - password
+                    - serverURL
+                    - username
                     type: object
                   senhasegura:
                     description: Senhasegura configures this store to sync secrets
@@ -5247,6 +5319,11 @@ spec:
                           the option is enabled serverside.
                           https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                         type: boolean
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: Headers to be added in Vault request
+                        type: object
                       namespace:
                         description: |-
                           Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
@@ -9522,6 +9599,9 @@ spec:
                       externalID:
                         description: AWS External ID set on assumed IAM roles
                         type: string
+                      prefix:
+                        description: Prefix adds a prefix to all retrieved values.
+                        type: string
                       region:
                         description: AWS Region to be used for the provider
                         type: string
@@ -11076,7 +11156,7 @@ spec:
                             type: object
                         type: object
                       apiUrl:
-                        default: https://api.pulumi.com
+                        default: https://api.pulumi.com/api/preview
                         description: APIURL is the URL of the Pulumi API.
                         type: string
                       environment:
@@ -11169,6 +11249,75 @@ spec:
                     - projectId
                     - region
                     - secretKey
+                    type: object
+                  secretserver:
+                    description: |-
+                      SecretServer configures this store to sync secrets using SecretServer provider
+                      https://docs.delinea.com/online-help/secret-server/start.htm
+                    properties:
+                      password:
+                        description: Password is the secret server account password.
+                        properties:
+                          secretRef:
+                            description: SecretRef references a key in a secret that
+                              will be used as value.
+                            properties:
+                              key:
+                                description: |-
+                                  The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                  defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                  to the namespace of the referent.
+                                type: string
+                            type: object
+                          value:
+                            description: Value can be specified directly to set a
+                              value without using a secret.
+                            type: string
+                        type: object
+                      serverURL:
+                        description: |-
+                          ServerURL
+                          URL to your secret server installation
+                        type: string
+                      username:
+                        description: Username is the secret server account username.
+                        properties:
+                          secretRef:
+                            description: SecretRef references a key in a secret that
+                              will be used as value.
+                            properties:
+                              key:
+                                description: |-
+                                  The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                  defaulted, in others it may be required.
+                                type: string
+                              name:
+                                description: The name of the Secret resource being
+                                  referred to.
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                  to the namespace of the referent.
+                                type: string
+                            type: object
+                          value:
+                            description: Value can be specified directly to set a
+                              value without using a secret.
+                            type: string
+                        type: object
+                    required:
+                    - password
+                    - serverURL
+                    - username
                     type: object
                   senhasegura:
                     description: Senhasegura configures this store to sync secrets
@@ -11770,6 +11919,11 @@ spec:
                           the option is enabled serverside.
                           https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                         type: boolean
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: Headers to be added in Vault request
+                        type: object
                       namespace:
                         description: |-
                           Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
@@ -12738,6 +12892,11 @@ spec:
                       the option is enabled serverside.
                       https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
                     type: boolean
+                  headers:
+                    additionalProperties:
+                      type: string
+                    description: Headers to be added in Vault request
+                    type: object
                   namespace:
                     description: |-
                       Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
@@ -13009,8 +13168,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets
   namespace: kube-system
 ---
@@ -13021,8 +13180,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-cert-controller
   namespace: kube-system
 ---
@@ -13033,8 +13192,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13045,8 +13204,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-leaderelection
   namespace: kube-system
 rules:
@@ -13083,8 +13242,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-cert-controller
 rules:
 - apiGroups:
@@ -13149,8 +13308,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-controller
 rules:
 - apiGroups:
@@ -13260,8 +13419,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit
@@ -13304,8 +13463,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:
@@ -13325,8 +13484,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -13366,8 +13525,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-leaderelection
   namespace: kube-system
 roleRef:
@@ -13386,8 +13545,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-cert-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13405,8 +13564,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13424,9 +13583,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.20
+    app.kubernetes.io/version: v0.10.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.9.20
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13437,9 +13596,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.20
+    app.kubernetes.io/version: v0.10.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.9.20
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -13460,8 +13619,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets
   namespace: kube-system
 spec:
@@ -13477,8 +13636,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.9.20
-        helm.sh/chart: external-secrets-0.9.20
+        app.kubernetes.io/version: v0.10.0
+        helm.sh/chart: external-secrets-0.10.0
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13487,7 +13646,7 @@ spec:
         - --metrics-addr=:8080
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: ghcr.io/external-secrets/external-secrets:v0.9.20
+        image: ghcr.io/external-secrets/external-secrets:v0.10.0
         imagePullPolicy: IfNotPresent
         name: external-secrets
         ports:
@@ -13519,8 +13678,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-cert-controller
   namespace: kube-system
 spec:
@@ -13536,8 +13695,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-cert-controller
-        app.kubernetes.io/version: v0.9.20
-        helm.sh/chart: external-secrets-0.9.20
+        app.kubernetes.io/version: v0.10.0
+        helm.sh/chart: external-secrets-0.10.0
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13553,7 +13712,7 @@ spec:
         - --loglevel=info
         - --zap-time-encoding=epoch
         - --enable-partial-cache=true
-        image: ghcr.io/external-secrets/external-secrets:v0.9.20
+        image: ghcr.io/external-secrets/external-secrets:v0.10.0
         imagePullPolicy: IfNotPresent
         name: cert-controller
         ports:
@@ -13590,8 +13749,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.9.20
-    helm.sh/chart: external-secrets-0.9.20
+    app.kubernetes.io/version: v0.10.0
+    helm.sh/chart: external-secrets-0.10.0
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -13607,8 +13766,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.9.20
-        helm.sh/chart: external-secrets-0.9.20
+        app.kubernetes.io/version: v0.10.0
+        helm.sh/chart: external-secrets-0.10.0
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13622,7 +13781,7 @@ spec:
         - --healthz-addr=:8081
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: ghcr.io/external-secrets/external-secrets:v0.9.20
+        image: ghcr.io/external-secrets/external-secrets:v0.10.0
         imagePullPolicy: IfNotPresent
         name: webhook
         ports:

--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -5,7 +5,7 @@ helmCharts:
 - name: external-secrets
   namespace: kube-system
   repo: https://charts.external-secrets.io
-  version: '0.9.20'
+  version: '0.10.0'
   releaseName: external-secrets
   includeCRDs: true
   valuesFile: values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version               = "0.9.20"
+  version               = "0.10.0"
   external_secrets_yaml = file("${path.module}/external-secrets.yaml")
   external_secrets_store_yaml = templatefile("${path.module}/cluster-secret-store.yaml", {
     region = var.region


### PR DESCRIPTION



<Actions>
    <action id="0eb2ac8a3a9cb140b2ce30320ef08c2c349c525fc20928591c662dc122c9c9bd">
        <h3>EXTERNAL-SECRETS.YAML</h3>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.9.20&#34; to &#34;0.10.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>0.10.0</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-08-03 07:44:31.429972553 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.0/external-secrets-0.10.0.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf external-secrets/charts &amp;&amp; kubectl kustomize . -o external-secrets.yaml --enable-helm &amp;&amp; git diff --shortstat external-secrets.yaml&#34;</p>
        </details>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;0.9.20&#39;&#34; to &#34;&#39;0.10.0&#39;&#34;, in file &#34;external-secrets/kustomization.yaml&#34;</p>
            <details>
                <summary>0.10.0</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-08-03 07:44:31.429972553 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.0/external-secrets-0.10.0.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-external-secrets-operator/actions/runs/10232116959">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

