### PR TITLE
Update External Secrets Operator version

### DIFF
--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: acraccesstokens.generators.external-secrets.io
@@ -206,7 +206,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: clusterexternalsecrets.external-secrets.io
@@ -903,7 +903,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: clustersecretstores.external-secrets.io
@@ -5852,7 +5852,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: ecrauthorizationtokens.generators.external-secrets.io
@@ -6024,7 +6024,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: externalsecrets.external-secrets.io
@@ -6870,7 +6870,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: fakes.generators.external-secrets.io
@@ -6947,7 +6947,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: gcraccesstokens.generators.external-secrets.io
@@ -7079,7 +7079,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: githubaccesstokens.generators.external-secrets.io
@@ -7183,7 +7183,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: passwords.generators.external-secrets.io
@@ -7282,7 +7282,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: pushsecrets.external-secrets.io
 spec:
   conversion:
@@ -7674,7 +7674,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: secretstores.external-secrets.io
@@ -12623,7 +12623,70 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: uuids.generators.external-secrets.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: kube-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: generators.external-secrets.io
+  names:
+    categories:
+    - password
+    kind: UUID
+    listKind: UUIDList
+    plural: uuids
+    shortNames:
+    - uuids
+    singular: uuid
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Password generates a random password based on the
+          configuration parameters in spec.
+          You can specify the length, characterset and other attributes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UUIDSpec controls the behavior of the uuid generator.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: vaultdynamicsecrets.generators.external-secrets.io
@@ -13354,7 +13417,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.2
   labels:
     external-secrets.io/component: controller
   name: webhooks.generators.external-secrets.io
@@ -13511,8 +13574,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets
   namespace: kube-system
 ---
@@ -13523,8 +13586,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-cert-controller
   namespace: kube-system
 ---
@@ -13535,8 +13598,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13547,8 +13610,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-leaderelection
   namespace: kube-system
 rules:
@@ -13585,8 +13648,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-cert-controller
 rules:
 - apiGroups:
@@ -13659,8 +13722,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-controller
 rules:
 - apiGroups:
@@ -13770,8 +13833,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit
@@ -13814,8 +13877,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:
@@ -13835,8 +13898,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -13876,8 +13939,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-leaderelection
   namespace: kube-system
 roleRef:
@@ -13896,8 +13959,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-cert-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13915,8 +13978,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13934,9 +13997,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.2
+    app.kubernetes.io/version: v0.10.3
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.2
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13947,9 +14010,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.2
+    app.kubernetes.io/version: v0.10.3
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.2
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -13970,8 +14033,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets
   namespace: kube-system
 spec:
@@ -13987,8 +14050,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.10.2
-        helm.sh/chart: external-secrets-0.10.2
+        app.kubernetes.io/version: v0.10.3
+        helm.sh/chart: external-secrets-0.10.3
     spec:
       automountServiceAccountToken: true
       containers:
@@ -13997,7 +14060,7 @@ spec:
         - --metrics-addr=:8080
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: ghcr.io/external-secrets/external-secrets:v0.10.2
+        image: ghcr.io/external-secrets/external-secrets:v0.10.3
         imagePullPolicy: IfNotPresent
         name: external-secrets
         ports:
@@ -14029,8 +14092,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-cert-controller
   namespace: kube-system
 spec:
@@ -14046,8 +14109,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-cert-controller
-        app.kubernetes.io/version: v0.10.2
-        helm.sh/chart: external-secrets-0.10.2
+        app.kubernetes.io/version: v0.10.3
+        helm.sh/chart: external-secrets-0.10.3
     spec:
       automountServiceAccountToken: true
       containers:
@@ -14063,7 +14126,7 @@ spec:
         - --loglevel=info
         - --zap-time-encoding=epoch
         - --enable-partial-cache=true
-        image: ghcr.io/external-secrets/external-secrets:v0.10.2
+        image: ghcr.io/external-secrets/external-secrets:v0.10.3
         imagePullPolicy: IfNotPresent
         name: cert-controller
         ports:
@@ -14100,8 +14163,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.2
-    helm.sh/chart: external-secrets-0.10.2
+    app.kubernetes.io/version: v0.10.3
+    helm.sh/chart: external-secrets-0.10.3
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -14117,8 +14180,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.10.2
-        helm.sh/chart: external-secrets-0.10.2
+        app.kubernetes.io/version: v0.10.3
+        helm.sh/chart: external-secrets-0.10.3
     spec:
       automountServiceAccountToken: true
       containers:
@@ -14132,7 +14195,7 @@ spec:
         - --healthz-addr=:8081
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: ghcr.io/external-secrets/external-secrets:v0.10.2
+        image: ghcr.io/external-secrets/external-secrets:v0.10.3
         imagePullPolicy: IfNotPresent
         name: webhook
         ports:

--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -5,7 +5,7 @@ helmCharts:
 - name: external-secrets
   namespace: kube-system
   repo: https://charts.external-secrets.io
-  version: '0.10.2'
+  version: '0.10.3'
   releaseName: external-secrets
   includeCRDs: true
   valuesFile: values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version               = "0.10.2"
+  version               = "0.10.3"
   external_secrets_yaml = file("${path.module}/external-secrets.yaml")
   external_secrets_store_yaml = templatefile("${path.module}/cluster-secret-store.yaml", {
     region = var.region


### PR DESCRIPTION



<Actions>
    <action id="0eb2ac8a3a9cb140b2ce30320ef08c2c349c525fc20928591c662dc122c9c9bd">
        <h3>EXTERNAL-SECRETS.YAML</h3>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;0.10.2&#39;&#34; to &#34;&#39;0.10.3&#39;&#34;, in file &#34;external-secrets/kustomization.yaml&#34;</p>
            <details>
                <summary>0.10.3</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-09-09 15:17:10.930301466 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.3/external-secrets-0.10.3.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.10.2&#34; to &#34;0.10.3&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>0.10.3</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-09-09 15:17:10.930301466 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.3/external-secrets-0.10.3.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf external-secrets/charts &amp;&amp; kubectl kustomize . -o external-secrets.yaml --enable-helm &amp;&amp; git diff --shortstat external-secrets.yaml&#34;</p>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-external-secrets-operator/actions/runs/10783613496">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

