### PR TITLE
chore(deps): update External Secrets Operator version

### DIFF
--- a/external-secrets.yaml
+++ b/external-secrets.yaml
@@ -13914,8 +13914,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets
   namespace: kube-system
 ---
@@ -13926,8 +13926,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-cert-controller
   namespace: kube-system
 ---
@@ -13938,8 +13938,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -13950,8 +13950,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-leaderelection
   namespace: kube-system
 rules:
@@ -13988,8 +13988,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-cert-controller
 rules:
 - apiGroups:
@@ -14062,8 +14062,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-controller
 rules:
 - apiGroups:
@@ -14173,8 +14173,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit
@@ -14217,8 +14217,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:
@@ -14238,8 +14238,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -14279,8 +14279,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-leaderelection
   namespace: kube-system
 roleRef:
@@ -14299,8 +14299,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-cert-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14318,8 +14318,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14337,9 +14337,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
+    app.kubernetes.io/version: v0.10.7
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.6
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-webhook
   namespace: kube-system
 ---
@@ -14350,9 +14350,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
+    app.kubernetes.io/version: v0.10.7
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.6
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -14373,8 +14373,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets
   namespace: kube-system
 spec:
@@ -14390,8 +14390,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.10.6
-        helm.sh/chart: external-secrets-0.10.6
+        app.kubernetes.io/version: v0.10.7
+        helm.sh/chart: external-secrets-0.10.7
     spec:
       automountServiceAccountToken: true
       containers:
@@ -14400,7 +14400,7 @@ spec:
         - --metrics-addr=:8080
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.6
+        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.7
         imagePullPolicy: IfNotPresent
         name: external-secrets
         ports:
@@ -14432,8 +14432,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-cert-controller
   namespace: kube-system
 spec:
@@ -14449,8 +14449,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-cert-controller
-        app.kubernetes.io/version: v0.10.6
-        helm.sh/chart: external-secrets-0.10.6
+        app.kubernetes.io/version: v0.10.7
+        helm.sh/chart: external-secrets-0.10.7
     spec:
       automountServiceAccountToken: true
       containers:
@@ -14466,7 +14466,7 @@ spec:
         - --loglevel=info
         - --zap-time-encoding=epoch
         - --enable-partial-cache=true
-        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.6
+        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.7
         imagePullPolicy: IfNotPresent
         name: cert-controller
         ports:
@@ -14503,8 +14503,8 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
-    helm.sh/chart: external-secrets-0.10.6
+    app.kubernetes.io/version: v0.10.7
+    helm.sh/chart: external-secrets-0.10.7
   name: external-secrets-webhook
   namespace: kube-system
 spec:
@@ -14520,8 +14520,8 @@ spec:
         app.kubernetes.io/instance: external-secrets
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.10.6
-        helm.sh/chart: external-secrets-0.10.6
+        app.kubernetes.io/version: v0.10.7
+        helm.sh/chart: external-secrets-0.10.7
     spec:
       automountServiceAccountToken: true
       containers:
@@ -14535,7 +14535,7 @@ spec:
         - --healthz-addr=:8081
         - --loglevel=info
         - --zap-time-encoding=epoch
-        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.6
+        image: oci.external-secrets.io/external-secrets/external-secrets:v0.10.7
         imagePullPolicy: IfNotPresent
         name: webhook
         ports:
@@ -14583,9 +14583,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
+    app.kubernetes.io/version: v0.10.7
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.6
+    helm.sh/chart: external-secrets-0.10.7
   name: externalsecret-validate
 webhooks:
 - admissionReviewVersions:
@@ -14620,9 +14620,9 @@ metadata:
     app.kubernetes.io/instance: external-secrets
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.10.6
+    app.kubernetes.io/version: v0.10.7
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.10.6
+    helm.sh/chart: external-secrets-0.10.7
   name: secretstore-validate
 webhooks:
 - admissionReviewVersions:

--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -5,7 +5,7 @@ helmCharts:
 - name: external-secrets
   namespace: kube-system
   repo: https://charts.external-secrets.io
-  version: '0.10.6'
+  version: '0.10.7'
   releaseName: external-secrets
   includeCRDs: true
   valuesFile: values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version               = "0.10.6"
+  version               = "0.10.7"
   external_secrets_yaml = file("${path.module}/external-secrets.yaml")
   external_secrets_store_yaml = templatefile("${path.module}/cluster-secret-store.yaml", {
     region = var.region


### PR DESCRIPTION



<Actions>
    <action id="0eb2ac8a3a9cb140b2ce30320ef08c2c349c525fc20928591c662dc122c9c9bd">
        <h3>EXTERNAL-SECRETS.YAML</h3>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.10.6&#34; to &#34;0.10.7&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>0.10.7</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-11-23 09:02:40.334211256 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.7/external-secrets-0.10.7.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf external-secrets/charts &amp;&amp; kubectl kustomize . -o external-secrets.yaml --enable-helm&#34;</p>
        </details>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;0.10.6&#39;&#34; to &#34;&#39;0.10.7&#39;&#34;, in file &#34;external-secrets/kustomization.yaml&#34;</p>
            <details>
                <summary>0.10.7</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-secrets&#xA;External secret management for Kubernetes&#xA;Project Home: https://github.com/external-secrets/external-secrets&#xA;Require Kubernetes Version: &amp;gt;= 1.19.0-0&#xA;Version created on the 2024-11-23 09:02:40.334211256 &amp;#43;0000 UTC&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/external-secrets/external-secrets/releases/download/helm-chart-0.10.7/external-secrets-0.10.7.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-external-secrets-operator/actions/runs/11991749317">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

