### PR TITLE
chore(deps): update External Secrets Operator version to lastRelease

### DIFF
--- a/updatecli/updatecli.d/external-secrets.yaml
+++ b/updatecli/updatecli.d/external-secrets.yaml
@@ -7,7 +7,7 @@ sources:
 
 targets:
   chart:
-    name: bump chart version
+    name: bump chart version to {{ source "lastRelease" }}
     kind: yaml
     scmid: github
     spec:
@@ -17,7 +17,7 @@ targets:
     - addprefix: "'"
     - addsuffix: "'"
   module_version:
-    name: bump operator module version
+    name: bump operator module version to {{ source "lastRelease" }}
     kind: hcl
     scmid: github
     spec:
@@ -67,4 +67,4 @@ actions:
       draft: false
       labels:
       - "dependencies"
-      title: "chore(deps): update External Secrets Operator version"
+      title: 'chore(deps): update External Secrets Operator version to {{ source "lastRelease" }}'


### PR DESCRIPTION
Update target names and titles to specify the last release in the 
external-secrets.yaml configuration. This change clarifies the purpose 
of the updates and aligns with versioning best practices, ensuring 
consistency in project documentation.