### PR TITLE
chore: remove pull request trigger for Updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,10 +5,6 @@ on:
   # Trigger Updatecli if a new commit land on the main branch
   push:
     branches: [ main ]
-  # Trigger Updatecli if a pullrequest is open targeting the main branch.
-  # This is useful to test Updatecli manifest change
-  pull_request:
-    branches: [ main ]
   # Manually trigger Updatecli via GitHub UI
   workflow_dispatch:
   # Trigger Updatecli once day by a cronjob


### PR DESCRIPTION
This change removes the pull request trigger from the Updatecli
workflow configuration. The pull request trigger is no longer
necessary as the main focus is on running the workflow for direct
pushes to the main branch. This simplifies the workflow and
ensures it only activates on relevant events.