### PR TITLE
refactor(external-secrets): remove unnecessary transformers

### DIFF
--- a/updatecli/updatecli.d/external-secrets.yaml
+++ b/updatecli/updatecli.d/external-secrets.yaml
@@ -13,9 +13,6 @@ targets:
     spec:
       file: 'external-secrets/kustomization.yaml'
       key: '$.helmCharts[0].version'
-    transformers:
-    - addprefix: "'"
-    - addsuffix: "'"
   module_version:
     name: bump operator module version to {{ source "lastRelease" }}
     kind: hcl


### PR DESCRIPTION
Remove the addprefix and addsuffix transformers from the 
external-secrets.yaml file as they are not needed for the 
current configuration. This simplification enhances the 
readability and maintainability of the code.