### PR TITLE
feat: update Terraform configurations and dependency versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        tf-version: [ 1.1.9, 1.2.9, 1.3.2 ]
+        tf-version: [ 1.3.2 ]
     steps:
       - name: Install terraform v${{ matrix.tf-version }}
         run: |
@@ -19,6 +19,11 @@ jobs:
           rm *
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Start LocalStack
+        uses: LocalStack/setup-localstack@v0.2.3
+        with:
+          image-tag: 'latest'
+          install-awslocal: 'true'
       - name: Validate examples terraform v${{ matrix.tf-version }}
         run: make examples
   build:

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -9,19 +9,22 @@ provider "aws" {
   region                      = "eu-west-1"
   access_key                  = "mock_access_key"
   secret_key                  = "mock_secret_key"
+  endpoints {
+    ec2 = "http://localhost:4566"
+  }
 }
 
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "~> 1.21"
+      source  = "terraform-kops/kops"
+      version = "~> 1.31"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Remove outdated Terraform versions and update to a single version 1.3.2. 
Add LocalStack setup to the CI workflow for better testing of AWS 
services. Modify provider sources and versions in Terraform files to 
ensure compatibility with newer modules and features. Update 
kubernetes version to 1.31.4 and adjust configurations accordingly.