### PR TITLE
feat(config): disable kustomize integration in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>opzkit/renovate-config"
-  ]
+  ],
+  "kustomize": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Disables the kustomize integration in the Renovate configuration to 
prevent unnecessary updates related to Kustomize files. This change 
improves the efficiency of the dependency management process.