### PR TITLE
ci(updatecli): enable squash merging and title usage for automerge

### DIFF
--- a/updatecli/updatecli.d/external-secrets.yaml
+++ b/updatecli/updatecli.d/external-secrets.yaml
@@ -61,6 +61,8 @@ actions:
     scmid: "github"
     spec:
       automerge: true
+      mergemethod: squash
+      usetitleforautomerge: true
       draft: false
       labels:
       - "dependencies"


### PR DESCRIPTION
Add squash merging method and configure to use title for
automerge in external-secrets.yaml. This streamlines commit history
and improves clarity in pull request merges.