### PR TITLE
fix: update apiVersion for ClusterSecretStore

### DIFF
--- a/cluster-secret-store.yaml
+++ b/cluster-secret-store.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: external-secrets


### PR DESCRIPTION
Update the apiVersion of ClusterSecretStore from v1beta1 to v1 to 
ensure compatibility with the latest API standards and improve 
stability of the application.